### PR TITLE
Add method to get custom "Publish" text

### DIFF
--- a/dataverse/connection.py
+++ b/dataverse/connection.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import json
 from lxml import etree
 import requests
 
@@ -96,3 +97,15 @@ class Connection(object):
     def get_dataverse(self, alias, refresh=False):
         return next((dataverse for dataverse in self.get_dataverses(refresh)
                      if dataverse.alias == alias), None)
+
+    def get_custom_publish_text(self):
+        resp = requests.get(
+            '{0}/info/settings/:DatasetPublishPopupCustomText'.format(self.native_base_url),
+            params={'key': self.token}
+        )
+        if resp.status_code != 200:
+            raise exceptions.OperationFailedError(
+                'Custom publish text could not be found.'
+            )
+
+        return json.loads(resp.content)['data']['message']


### PR DESCRIPTION
Exposes custom text set per Dataverse instance that (typically) specifies license agreements, etc. before publishing a dataset.

![custom text](https://cloud.githubusercontent.com/assets/5659262/17442436/c148d0b6-5b03-11e6-87eb-642177508c4f.jpg)

See https://github.com/CenterForOpenScience/osf.io/pull/5344#issuecomment-237318478
