### PR TITLE
[PLAT-1003] Stringify content-length header to fix requests bug

### DIFF
--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -250,7 +250,7 @@ class Dataset(object):
 
         resp = requests.post(
             self.edit_uri,
-            headers={'In-Progress': 'false', 'Content-Length': 0},
+            headers={'In-Progress': 'false', 'Content-Length': '0'},
             auth=self.connection.auth,
         )
 


### PR DESCRIPTION
## Purpose

Current publishing a Dataverse creates the following error: 
```python
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/code/framework/routing/__init__.py", line 117, in wrapped
    data = fn(*args, **kwargs)
  File "/code/website/project/decorators.py", line 403, in wrapped
    return func(*args, **kwargs)
  File "/code/website/project/decorators.py", line 162, in wrapped
    return func(*args, **kwargs)
  File "/code/framework/auth/decorators.py", line 41, in wrapped
    return func(*args, **kwargs)
  File "/code/website/project/decorators.py", line 326, in wrapped
    return func(*args, **kwargs)
  File "/code/framework/auth/decorators.py", line 41, in wrapped
    return func(*args, **kwargs)
  File "/code/website/project/decorators.py", line 364, in wrapped
    return func(*args, **kwargs)
  File "/code/addons/dataverse/views.py", line 184, in dataverse_publish_dataset
    client.publish_dataset(dataset)
  File "/code/addons/dataverse/client.py", line 76, in publish_dataset
    dataset.publish()
  File "/code/src/dataverse/dataverse/dataset.py", line 254, in publish
    auth=self.connection.auth,
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 112, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/usr/local/lib/python2.7/site-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
InvalidHeader: Value for header {Content-Length: 0} must be of type str or bytes, not <type 'int'>
``` 

This PR fixes that.

## Changes

- Stringifys content-length header which is invalid

## QA Notes

Create a new Dataverse on the demo.datverse.org Dataverse Repo, create a dataset with files, then publish it. It should be successful.

## Side Effects

Older Dataverse still do not publish, but this is because of EZID, not OSF-side issues. Newly created dataverses should always publish.

## Ticket 
https://openscience.atlassian.net/browse/PLAT-1003