### PR TITLE
Feature/Handle nested dataverses[PLAT-1328]

### DIFF
--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -98,14 +98,15 @@ class Dataset(object):
             raise NoContainerError('This dataset has not been added to a Dataverse.')
 
         for dataset in self.dataverse.get_contents(refresh=True):
-            doi = '{0}:{1}/{2}'.format(
-                dataset['protocol'],
-                dataset['authority'],
-                dataset['identifier'],
-            )
-            if doi == self.doi:
-                self._id = dataset['id']
-                return self._id
+            if dataset['type'] == 'dataset':
+                doi = '{0}:{1}/{2}'.format(
+                    dataset['protocol'],
+                    dataset['authority'],
+                    dataset['identifier'],
+                )
+                if doi == self.doi:
+                    self._id = dataset['id']
+                    return self._id
 
         raise MetadataNotFoundError('The dataset ID could not be found.')
 

--- a/dataverse/test/test_dataverse.py
+++ b/dataverse/test/test_dataverse.py
@@ -292,6 +292,19 @@ class TestDatasetOperations(DataverseServerTestBase):
         assert retrieved_dataset
         self.dataverse.delete_dataset(retrieved_dataset)
 
+    def test_id_property(self):
+        alias = str(uuid.uuid1())
+        # Creating a dataverse within a dataverse
+        self.connection.create_dataverse(
+            alias,
+            'Sub Dataverse',
+            'dataverse@example.com',
+            self.alias,
+        )
+        sub_dataverse = self.connection.get_dataverse(alias, True)
+        assert self.dataset.id == self.dataset._id
+        self.connection.delete_dataverse(sub_dataverse)
+
     def test_add_files(self):
         self.dataset.upload_filepaths(EXAMPLE_FILES)
         actual_files = [f.name for f in self.dataset.get_files()]


### PR DESCRIPTION
# Purpose

We're getting a Key Error if someone has a nested dataverse inside of a dataverse when connecting a dataset. thanks @felliott for pointing me towards the fix.

# Changes
On the `Dataset.id` property, when looping through the contents of a dataverse, verify that the resource type is a "dataset" before attempting to access the "protocol" key.

# To Duplicate
Create a test dataverse on https://demo.dataverse.org/, and then add both a dataverse and a dataset to that top-level dataverse.  (Create the nested dataverse first).   

So I had dataverse Grapes Dataverse, with a Raisins Dataverse and a strawberries dataset.
<img width="1219" alt="screen shot 2019-02-08 at 12 17 59 pm" src="https://user-images.githubusercontent.com/9755598/52500536-daadd600-2ba3-11e9-973d-a131744d4aa3.png">

On the OSF connect your Grapes Dataverse, select your strawberries dataset and hit save.  Before, you would get a key error when the _id property would loop through all the content in Grapes Dataverse (Raisins Dataverse and strawberries dataset). If it hit a dataverse before finding the matching dataset, it would get an error when looking for the `protocol` key which doesn't exist on a dataverse.

# Ticket
https://openscience.atlassian.net/browse/PLAT-1328